### PR TITLE
Enable IPv6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - ./config:/config
       - /lib/modules:/lib/modules
     sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
       - net.ipv4.conf.all.src_valid_mark=1
     restart: unless-stopped
   transmission:


### PR DESCRIPTION
As now several VPN provider assign a IPv6 address, their config files would result in a failure when wireguard tries to bind the address to the wg0 interface as v6 is dissabled by default. As a result the wireguard container starts without a active VPN connection what could lead to a unnoticed ip leak.